### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,28 +36,28 @@
     "node": ">=0.10.26"
   },
   "dependencies": {
-    "indexeddbshim": "^2.2.1",
-    "json-stable-stringify": "^1.0.0",
-    "level-delete-range": "^0.1.0",
-    "level-sublevel": "^5.2.3",
+    "indexeddbshim": "2.2.1",
+    "json-stable-stringify": "1.0.0",
+    "level-delete-range": "0.1.0",
+    "level-sublevel": "5.2.3",
     "map-stream": "0.0.6",
-    "monot": "^0.1.2"
+    "monot": "0.1.2"
   },
   "devDependencies": {
-    "bulkify": "^1.1.1",
-    "engine.io-stream": "^0.4.3",
+    "bulkify": "1.1.1",
+    "engine.io-stream": "0.4.3",
     "faucet": "0.0.1",
-    "function-bind": "^1.0.2",
-    "hyperquest": "^1.2.0",
-    "level-js": "^2.2.1",
-    "level-proxy": "^1.1.2",
-    "leveldown": "^1.4.1",
-    "levelup": "^0.19.0",
-    "multilevel": "^6.1.0",
-    "remove-saucelabs-jobs-by-build": "^1.0.0",
-    "rimraf": "^2.4.3",
-    "standard": "^5.2.1",
-    "tape": "^4.2.0",
-    "zuul": "^3.4.0"
+    "function-bind": "1.0.2",
+    "hyperquest": "1.2.0",
+    "level-js": "2.2.2",
+    "level-proxy": "1.1.2",
+    "leveldown": "1.4.1",
+    "levelup": "0.19.0",
+    "multilevel": "6.2.1",
+    "remove-saucelabs-jobs-by-build": "1.0.0",
+    "rimraf": "2.4.3",
+    "standard": "5.3.1",
+    "tape": "4.2.0",
+    "zuul": "3.6.0"
   }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>